### PR TITLE
Add inline JSON body and localhost URL shorthand

### DIFF
--- a/METADATA
+++ b/METADATA
@@ -1,5 +1,5 @@
 [VERSION]
-1.1.1
+1.1.2
 
 [WEBSITE]
 https://httpzen.diogopereira.site

--- a/cmd/commands/request/command.go
+++ b/cmd/commands/request/command.go
@@ -1,7 +1,6 @@
 package request_command
 
 import (
-	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -38,128 +37,122 @@ func parseHeaders(headers []string) http.Header {
 	return result
 }
 
-func isUrl(s string) bool {
-	if len(s) > 1 && s[0] == ':' && s[1] >= '0' && s[1] <= '9' {
-		return true
+func parseMethodUrlAndRemainingArgs(cmd *cobra.Command, args []string) (method string, url string, remainingArgs []string, ok bool) {
+	if len(args) < 1 {
+		cmd.Help()
+		return "", "", nil, false
 	}
-	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+
+	if http_utility.CheckIsUrl(args[0]) {
+		return "GET", args[0], args[1:], true
+	}
+
+	if len(args) < 2 {
+		cmd.Help()
+		return "", "", nil, false
+	}
+
+	method = http_utility.ParseHttpMethod(args[0])
+	if method == "" {
+		logger_module.Error(
+			"Invalid HTTP method. Please provide a valid HTTP method (GET, POST, PATCH, PUT, DELETE, HEAD).",
+			70,
+		)
+		Exit(1)
+		return "", "", nil, false
+	}
+
+	return method, args[1], args[2:], true
 }
 
-func parseInlineBody(args []string) []http_utility.HttpContentData {
-	pairs := map[string]string{}
-	for _, arg := range args {
-		parts := strings.SplitN(arg, "=", 2)
-		if len(parts) == 2 {
-			key := parts[0]
-			value := parts[1]
-			// Remove surrounding quotes if present
-			value = strings.Trim(value, "\"")
-			pairs[key] = value
-		}
+func parseAndValidateUrl(url string) string {
+	parsedUrl := http_utility.ParseUrl(url)
+	if parsedUrl == "" {
+		logger_module.Error(
+			"Invalid URL. Please provide a valid URL (http:// or https://).",
+			70,
+		)
+		Exit(1)
+		return ""
+	}
+	return parsedUrl
+}
+
+func getRequestFlags(cmd *cobra.Command) RequestFlags {
+	headers, _ := cmd.Flags().GetStringSlice("header")
+	body, _ := cmd.Flags().GetBool("body")
+
+	return RequestFlags{
+		Headers: headers,
+		Body:    body,
+	}
+}
+
+func validateBodyAllowed(method string, wantsBody bool) bool {
+	if !wantsBody {
+		return true
+	}
+	if method == "GET" || method == "HEAD" {
+		logger_module.Error(
+			"Body cannot be included in GET or HEAD requests.",
+			70,
+		)
+		Exit(1)
+		return false
+	}
+	return true
+}
+
+func buildRequestOptions(cmd *cobra.Command, method string, parsedUrl string, flags RequestFlags) request_module.RequestOptions {
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	return request_module.RequestOptions{
+		Url:      parsedUrl,
+		Headers:  parseHeaders(flags.Headers),
+		Method:   method,
+		Timeout:  30 * time.Second,
+		Insecure: insecure,
+	}
+}
+
+func resolveRequestBody(requestOptions *request_module.RequestOptions, flags RequestFlags, inlineBody []http_utility.HttpContentData) []http_utility.HttpContentData {
+	if len(inlineBody) > 0 {
+		return inlineBody
 	}
 
-	if len(pairs) == 0 {
-		return nil
+	var body []http_utility.HttpContentData
+	if flags.Body {
+		BodyMenuNewFunc(requestOptions, &body)
 	}
+	return body
+}
 
-	jsonBytes, err := json.Marshal(pairs)
-	if err != nil {
-		return nil
-	}
-
-	return []http_utility.HttpContentData{
-		{
-			ContentType: "application/json",
-			Value:       string(jsonBytes),
-		},
-	}
+func registerFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("body", "b", false, "Include body in the request (default: false)")
+	cmd.Flags().StringSliceP("header", "H", []string{}, "Add a header to the request (can be used multiple times)")
+	cmd.Flags().BoolP("insecure", "k", false, "Allow insecure SSL certificates (Self-Signed)")
 }
 
 func Init(rootCmd *cobra.Command) {
 	rootCmd.Run = func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			cmd.Help()
+		method, url, remainingArgs, ok := parseMethodUrlAndRemainingArgs(cmd, args)
+		if !ok {
 			return
 		}
 
-		var method, url string
-		var remainingArgs []string
+		parsedUrl := parseAndValidateUrl(url)
+		flags := getRequestFlags(cmd)
 
-		if isUrl(args[0]) {
-			method = "GET"
-			url = args[0]
-			remainingArgs = args[1:]
-		} else {
-			if len(args) < 2 {
-				cmd.Help()
-				return
-			}
-			method = http_utility.ParseHttpMethod(args[0])
-			if method == "" {
-				logger_module.Error(
-					"Invalid HTTP method. Please provide a valid HTTP method (GET, POST, PATCH, PUT, DELETE, HEAD).",
-					70,
-				)
-				Exit(1)
-			}
-			url = args[1]
-			remainingArgs = args[2:]
-		}
-
-		parsedUrl := http_utility.ParseUrl(url)
-		if parsedUrl == "" {
-			logger_module.Error(
-				"Invalid URL. Please provide a valid URL (http:// or https://).",
-				70,
-			)
-			Exit(1)
-		}
-
-		headers, _ := cmd.Flags().GetStringSlice("header")
-		flags := RequestFlags{
-			Headers: headers,
-			Body:    cmd.Flag("body").Value.String() == "true",
-		}
-
-		// Parse inline body from remaining args (key=value pairs)
-		inlineBody := parseInlineBody(remainingArgs)
-		hasInlineBody := len(inlineBody) > 0
-
-		if (flags.Body || hasInlineBody) &&
-			(method == "GET" || method == "HEAD") {
-			logger_module.Error(
-				"Body cannot be included in GET or HEAD requests.",
-				70,
-			)
-			Exit(1)
+		inlineBody := http_utility.ParseInlineBody(remainingArgs)
+		wantsBody := flags.Body || len(inlineBody) > 0
+		if !validateBodyAllowed(method, wantsBody) {
 			return
 		}
 
-		insecure, _ := cmd.Flags().GetBool("insecure")
-		requestOptions := request_module.RequestOptions{
-			Url:      parsedUrl,
-			Headers:  parseHeaders(flags.Headers),
-			Method:   method,
-			Timeout:  30 * time.Second,
-			Insecure: insecure,
-		}
-
-		var body []http_utility.HttpContentData
-		if hasInlineBody {
-			body = inlineBody
-		} else if flags.Body {
-			BodyMenuNewFunc(&requestOptions, &body)
-		}
-		requestOptions.Body = body
+		requestOptions := buildRequestOptions(cmd, method, parsedUrl, flags)
+		requestOptions.Body = resolveRequestBody(&requestOptions, flags, inlineBody)
 
 		res := RunRequestFunc(requestOptions)
 		RequestMenuNewFunc(&res)
 	}
-
-	rootCmd.Flags().
-		BoolP("body", "b", false, "Include body in the request (default: false)")
-	rootCmd.Flags().
-		StringSliceP("header", "H", []string{}, "Add a header to the request (can be used multiple times)")
-	rootCmd.Flags().
-		BoolP("insecure", "k", false, "Allow insecure SSL certificates (Self-Signed)")
+	registerFlags(rootCmd)
 }

--- a/cmd/commands/request/command.go
+++ b/cmd/commands/request/command.go
@@ -1,6 +1,7 @@
 package request_command
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -38,7 +39,40 @@ func parseHeaders(headers []string) http.Header {
 }
 
 func isUrl(s string) bool {
+	if len(s) > 1 && s[0] == ':' && s[1] >= '0' && s[1] <= '9' {
+		return true
+	}
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+func parseInlineBody(args []string) []http_utility.HttpContentData {
+	pairs := map[string]string{}
+	for _, arg := range args {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) == 2 {
+			key := parts[0]
+			value := parts[1]
+			// Remove surrounding quotes if present
+			value = strings.Trim(value, "\"")
+			pairs[key] = value
+		}
+	}
+
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	jsonBytes, err := json.Marshal(pairs)
+	if err != nil {
+		return nil
+	}
+
+	return []http_utility.HttpContentData{
+		{
+			ContentType: "application/json",
+			Value:       string(jsonBytes),
+		},
+	}
 }
 
 func Init(rootCmd *cobra.Command) {
@@ -49,10 +83,12 @@ func Init(rootCmd *cobra.Command) {
 		}
 
 		var method, url string
+		var remainingArgs []string
 
 		if isUrl(args[0]) {
 			method = "GET"
 			url = args[0]
+			remainingArgs = args[1:]
 		} else {
 			if len(args) < 2 {
 				cmd.Help()
@@ -67,6 +103,7 @@ func Init(rootCmd *cobra.Command) {
 				Exit(1)
 			}
 			url = args[1]
+			remainingArgs = args[2:]
 		}
 
 		parsedUrl := http_utility.ParseUrl(url)
@@ -84,7 +121,12 @@ func Init(rootCmd *cobra.Command) {
 			Body:    cmd.Flag("body").Value.String() == "true",
 		}
 
-		if flags.Body && (method == "GET" || method == "HEAD") {
+		// Parse inline body from remaining args (key=value pairs)
+		inlineBody := parseInlineBody(remainingArgs)
+		hasInlineBody := len(inlineBody) > 0
+
+		if (flags.Body || hasInlineBody) &&
+			(method == "GET" || method == "HEAD") {
 			logger_module.Error(
 				"Body cannot be included in GET or HEAD requests.",
 				70,
@@ -103,7 +145,9 @@ func Init(rootCmd *cobra.Command) {
 		}
 
 		var body []http_utility.HttpContentData
-		if flags.Body {
+		if hasInlineBody {
+			body = inlineBody
+		} else if flags.Body {
 			BodyMenuNewFunc(&requestOptions, &body)
 		}
 		requestOptions.Body = body

--- a/cmd/commands/request/command_test.go
+++ b/cmd/commands/request/command_test.go
@@ -60,6 +60,7 @@ func Test_Init(t *testing.T) {
 		calledBodyMenu    bool
 		calledRunRequest  bool
 		calledRequestMenu bool
+		capturedOpts      request_module.RequestOptions
 	)
 
 	oldExit := Exit
@@ -75,6 +76,7 @@ func Test_Init(t *testing.T) {
 	oldRunRequest := RunRequestFunc
 	RunRequestFunc = func(opts request_module.RequestOptions) request_module.RequestResponse {
 		calledRunRequest = true
+		capturedOpts = opts
 		return request_module.RequestResponse{}
 	}
 	defer func() { RunRequestFunc = oldRunRequest }()
@@ -89,6 +91,22 @@ func Test_Init(t *testing.T) {
 		cmd := &cobra.Command{Use: "test"}
 		Init(cmd)
 		cmd.SetArgs([]string{})
+
+		var helpCalled bool
+		cmd.SetHelpFunc(func(*cobra.Command, []string) {
+			helpCalled = true
+		})
+
+		cmd.Execute()
+		if !helpCalled {
+			t.Error("expected help to be called")
+		}
+	})
+
+	t.Run("calls help if only method is provided", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		Init(cmd)
+		cmd.SetArgs([]string{"GET"})
 
 		var helpCalled bool
 		cmd.SetHelpFunc(func(*cobra.Command, []string) {
@@ -141,6 +159,27 @@ func Test_Init(t *testing.T) {
 		cmd.Execute()
 	})
 
+	t.Run("body not allowed returns early when Exit is no-op", func(t *testing.T) {
+		var exitCode int
+		oldExitLocal := Exit
+		Exit = func(code int) { exitCode = code }
+		defer func() { Exit = oldExitLocal }()
+
+		calledRunRequest = false
+		calledRequestMenu = false
+		cmd := &cobra.Command{Use: "test"}
+		Init(cmd)
+		cmd.SetArgs([]string{"GET", "http://test", "foo=bar"})
+		cmd.Execute()
+
+		if exitCode != 1 {
+			t.Errorf("expected exit code 1, got %d", exitCode)
+		}
+		if calledRunRequest || calledRequestMenu {
+			t.Error("expected request to not run when body is not allowed")
+		}
+	})
+
 	t.Run("body not allowed for HEAD", func(t *testing.T) {
 		cmd := &cobra.Command{Use: "test"}
 		Init(cmd)
@@ -168,6 +207,45 @@ func Test_Init(t *testing.T) {
 		if !calledBodyMenu || !calledRunRequest || !calledRequestMenu {
 			t.Error("expected all functions to be called")
 		}
+	})
+
+	t.Run("valid request with inline body (does not open body menu)", func(t *testing.T) {
+		calledBodyMenu = false
+		calledRunRequest = false
+		calledRequestMenu = false
+		capturedOpts = request_module.RequestOptions{}
+
+		cmd := &cobra.Command{Use: "test"}
+		Init(cmd)
+
+		cmd.SetArgs([]string{"POST", "http://test", "foo=\"bar\""})
+		cmd.Flags().Set("insecure", "true")
+		cmd.Execute()
+
+		if calledBodyMenu {
+			t.Error("expected body menu not to be called when inline body is provided")
+		}
+		if !calledRunRequest || !calledRequestMenu {
+			t.Error("expected RunRequestFunc and RequestMenuNewFunc to be called")
+		}
+		if len(capturedOpts.Body) == 0 {
+			t.Error("expected inline body to be set in request options")
+		}
+		if !capturedOpts.Insecure {
+			t.Error("expected insecure flag to be propagated")
+		}
+	})
+
+	t.Run("inline body not allowed for GET", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		Init(cmd)
+		cmd.SetArgs([]string{"GET", "http://test", "foo=bar"})
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected exit to be called")
+			}
+		}()
+		cmd.Execute()
 	})
 
 	t.Run("valid request without body", func(t *testing.T) {
@@ -212,6 +290,23 @@ func Test_Init(t *testing.T) {
 			t.Error(
 				"expected RunRequestFunc and RequestMenuNewFunc to be called",
 			)
+		}
+	})
+
+	t.Run("GET request with shorthand port URL only (no method)", func(t *testing.T) {
+		calledRunRequest = false
+		calledRequestMenu = false
+		capturedOpts = request_module.RequestOptions{}
+
+		cmd := &cobra.Command{Use: "test"}
+		Init(cmd)
+		cmd.SetArgs([]string{":8080/api"})
+		cmd.Execute()
+		if !calledRunRequest || !calledRequestMenu {
+			t.Error("expected RunRequestFunc and RequestMenuNewFunc to be called")
+		}
+		if capturedOpts.Url != "http://localhost:8080/api" {
+			t.Errorf("expected url to be expanded, got %q", capturedOpts.Url)
 		}
 	})
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "httpzen-docs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Documentation for HttpZen",
   "repository": {
     "type": "git",

--- a/internal/utils/http_utility/util.go
+++ b/internal/utils/http_utility/util.go
@@ -35,7 +35,10 @@ func ParseApplicationJson(data HttpContentData) HandleParseResult {
 		logger_module.Error("Failed to parse JSON body: "+err.Error(), 70)
 		return HandleParseResult{}
 	}
-	return HandleParseResult{ContentTypeHeader: data.ContentType, Result: jsonData}
+	return HandleParseResult{
+		ContentTypeHeader: data.ContentType,
+		Result:            jsonData,
+	}
 }
 
 func ParseMultipartFormData(data []HttpContentData) HandleParseResult {
@@ -45,7 +48,10 @@ func ParseMultipartFormData(data []HttpContentData) HandleParseResult {
 	for _, part := range data {
 		var unmarshalResult map[string]string
 		var pair []string
-		if err := json.Unmarshal([]byte(part.Value), &unmarshalResult); err != nil {
+		if err := json.Unmarshal(
+			[]byte(part.Value),
+			&unmarshalResult,
+		); err != nil {
 			pair = []string{part.Key, part.Value}
 		}
 
@@ -54,7 +60,10 @@ func ParseMultipartFormData(data []HttpContentData) HandleParseResult {
 				file, err := os.Open(part.Value)
 				if err == nil {
 					defer file.Close()
-					if fw, err2 := writer.CreateFormFile(part.Key, part.Value); err2 == nil {
+					if fw, err2 := writer.CreateFormFile(
+						part.Key,
+						part.Value,
+					); err2 == nil {
 						_, _ = io.Copy(fw, file)
 					}
 					continue
@@ -77,8 +86,16 @@ func ParseMultipartFormData(data []HttpContentData) HandleParseResult {
 func ParseUrlEncodedForm(data []HttpContentData) HandleParseResult {
 	var formParts []string
 	for _, part := range data {
-		encodedKey := strings.ReplaceAll(strings.ReplaceAll(part.Key, " ", "+"), "=", "%3D")
-		encodedValue := strings.ReplaceAll(strings.ReplaceAll(part.Value, " ", "+"), "=", "%3D")
+		encodedKey := strings.ReplaceAll(
+			strings.ReplaceAll(part.Key, " ", "+"),
+			"=",
+			"%3D",
+		)
+		encodedValue := strings.ReplaceAll(
+			strings.ReplaceAll(part.Value, " ", "+"),
+			"=",
+			"%3D",
+		)
 		formParts = append(formParts, encodedKey+"="+encodedValue)
 	}
 
@@ -110,7 +127,13 @@ func ParseHttpMethod(method string) string {
 }
 
 func ParseUrl(url string) string {
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+	// Localhost shorthand: :8080/path → http://localhost:8080/path
+	if len(url) > 1 && url[0] == ':' && url[1] >= '0' && url[1] <= '9' {
+		url = "http://localhost" + url
+	}
+
+	if !strings.HasPrefix(url, "http://") &&
+		!strings.HasPrefix(url, "https://") {
 		return ""
 	}
 	return url
@@ -130,10 +153,12 @@ func DetectContentType(result string) string {
 			return "json"
 		}
 	}
-	if strings.HasPrefix(trimmed, "<!DOCTYPE html") || strings.HasPrefix(trimmed, "<html") {
+	if strings.HasPrefix(trimmed, "<!DOCTYPE html") ||
+		strings.HasPrefix(trimmed, "<html") {
 		return "html"
 	}
-	if strings.HasPrefix(trimmed, "<?xml") || (strings.HasPrefix(trimmed, "<") && strings.HasSuffix(trimmed, ">")) {
+	if strings.HasPrefix(trimmed, "<?xml") ||
+		(strings.HasPrefix(trimmed, "<") && strings.HasSuffix(trimmed, ">")) {
 		return "xml"
 	}
 	return "text"

--- a/internal/utils/http_utility/util.go
+++ b/internal/utils/http_utility/util.go
@@ -107,6 +107,32 @@ func ParseUrlEncodedForm(data []HttpContentData) HandleParseResult {
 	}
 }
 
+func ParseInlineBody(args []string) []HttpContentData {
+	pairs := map[string]string{}
+	for _, arg := range args {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) == 2 {
+			key := parts[0]
+			value := parts[1]
+			value = strings.Trim(value, "\"")
+			pairs[key] = value
+		}
+	}
+
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	jsonBytes, _ := json.Marshal(pairs)
+
+	return []HttpContentData{
+		{
+			ContentType: "application/json",
+			Value:       string(jsonBytes),
+		},
+	}
+}
+
 func ParseHttpMethod(method string) string {
 	switch strings.ToLower(method) {
 	case "get":
@@ -127,14 +153,24 @@ func ParseHttpMethod(method string) string {
 }
 
 func ParseUrl(url string) string {
-	// Localhost shorthand: :8080/path → http://localhost:8080/path
-	if len(url) > 1 && url[0] == ':' && url[1] >= '0' && url[1] <= '9' {
-		url = "http://localhost" + url
-	}
+	url = ParsePortShorthand(url)
 
 	if !strings.HasPrefix(url, "http://") &&
 		!strings.HasPrefix(url, "https://") {
 		return ""
+	}
+	return url
+}
+
+func CheckIsUrl(text string) bool {
+	text = ParsePortShorthand(text)
+	return strings.HasPrefix(text, "http://") || strings.HasPrefix(text, "https://")
+}
+
+func ParsePortShorthand(url string) string {
+	// :8080/api/auth -> http://localhost:8080/api/auth
+	if len(url) > 1 && url[0] == ':' && url[1] >= '0' && url[1] <= '9' {
+		url = "http://localhost" + url
 	}
 	return url
 }

--- a/internal/utils/http_utility/util_test.go
+++ b/internal/utils/http_utility/util_test.go
@@ -169,6 +169,25 @@ func TestParseUrl(t *testing.T) {
 	if ParseUrl("ftp://foo") != "" {
 		t.Errorf("expected empty for invalid url")
 	}
+
+	if ParseUrl(":8080/api") != "http://localhost:8080/api" {
+		t.Errorf("expected shorthand port to be expanded")
+	}
+}
+
+func TestCheckIsUrl(t *testing.T) {
+	if !CheckIsUrl("http://foo") {
+		t.Errorf("expected http url to be detected")
+	}
+	if !CheckIsUrl("https://foo") {
+		t.Errorf("expected https url to be detected")
+	}
+	if !CheckIsUrl(":8080/api") {
+		t.Errorf("expected shorthand port url to be detected")
+	}
+	if CheckIsUrl("not-a-url") {
+		t.Errorf("expected non-url to be false")
+	}
 }
 
 func TestParseExecutionTimeInMilliseconds(t *testing.T) {
@@ -186,6 +205,10 @@ func TestDetectContentType(t *testing.T) {
 		t.Errorf("expected json")
 	}
 
+	if DetectContentType("{invalid json") != "text" {
+		t.Errorf("expected invalid json to fall back to text")
+	}
+
 	if DetectContentType("<html>") != "html" {
 		t.Errorf("expected html")
 	}
@@ -196,6 +219,29 @@ func TestDetectContentType(t *testing.T) {
 
 	if DetectContentType("plain text") != "text" {
 		t.Errorf("expected text")
+	}
+}
+
+func TestParseInlineBody(t *testing.T) {
+	if ParseInlineBody(nil) != nil {
+		t.Errorf("expected nil for empty args")
+	}
+	if ParseInlineBody([]string{"noequal"}) != nil {
+		t.Errorf("expected nil for args without key=value")
+	}
+
+	res := ParseInlineBody([]string{"foo=\"bar\"", "a=b"})
+	if len(res) != 1 {
+		t.Fatalf("expected 1 content item")
+	}
+	if res[0].ContentType != "application/json" {
+		t.Fatalf("expected application/json")
+	}
+	if !strings.Contains(res[0].Value, "\"foo\":\"bar\"") {
+		t.Errorf("expected quotes to be trimmed")
+	}
+	if !strings.Contains(res[0].Value, "\"a\":\"b\"") {
+		t.Errorf("expected second pair to be present")
 	}
 }
 
@@ -235,5 +281,50 @@ func TestGetFileByPath(t *testing.T) {
 
 	if !info.PathIsValid {
 		t.Errorf("expected valid path")
+	}
+
+	dir, err := os.MkdirTemp("", "test.dir*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	dirInfo, err := GetFileByPath(dir)
+	if err == nil {
+		t.Errorf("expected error for directory path")
+	}
+	if dirInfo == nil || !dirInfo.PathIsValid {
+		t.Errorf("expected PathIsValid=true for directory path")
+	}
+}
+
+func TestParseMultipartFormData_FilePermissionDeniedFallsBackToField(t *testing.T) {
+	file, err := os.CreateTemp("", "permtest*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := file.Name()
+	_, _ = file.WriteString("SHOULD_NOT_BE_INCLUDED")
+	file.Close()
+	defer os.Remove(name)
+
+	if err := os.Chmod(name, 0); err != nil {
+		t.Skipf("chmod not supported: %v", err)
+	}
+	defer os.Chmod(name, 0600)
+
+	data := []HttpContentData{{Key: "file1", Value: name}}
+	res := ParseMultipartFormData(data)
+	buf, ok := res.Result.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("expected buffer result")
+	}
+
+	body := buf.String()
+	if !strings.Contains(body, name) {
+		t.Errorf("expected multipart body to contain the file path value")
+	}
+	if strings.Contains(body, "SHOULD_NOT_BE_INCLUDED") {
+		t.Errorf("expected multipart body to not include file contents when open fails")
 	}
 }

--- a/pkgroot/DEBIAN/control
+++ b/pkgroot/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: httpzen
-Version: 1.1.1
+Version: 1.1.2
 Section: utils
 Priority: optional
 Architecture: all


### PR DESCRIPTION
This pull request enhances the request command-line interface by introducing support for inline JSON request bodies, improving URL parsing (including localhost shorthand), and refactoring utility functions for clarity and maintainability. The most significant changes are grouped below:

**New Features:**

* Added support for passing inline request bodies as key=value pairs directly in the command arguments, which are automatically encoded as JSON (`parseInlineBody` in `command.go`). [[1]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843R42-R77) [[2]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843L87-R129) [[3]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843L106-R150)
* Implemented shorthand parsing for localhost URLs (e.g., `:8080/path` is expanded to `http://localhost:8080/path`). [[1]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843R4) [[2]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843R86-R91) [[3]](diffhunk://#diff-0af5914436d021aad405714f40896fad753cc8c6e95d0b392794089a20821843R106) [[4]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L113-R136)

**Refactoring and Code Quality:**

* Refactored utility functions in `http_utility/util.go` to improve readability, including multi-line formatting for JSON unmarshalling, file handling, and URL encoding logic. [[1]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L38-R41) [[2]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L48-R54) [[3]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L57-R66) [[4]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L80-R98) [[5]](diffhunk://#diff-8252f42a53f6d69785db67e8277ce089c4be905ec3bb2a0395af97f988917e65L133-R161)

These updates make it easier to craft HTTP requests with inline data and improve the developer experience when working with local endpoints.